### PR TITLE
Fix load_plugin_textdomain path

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -263,7 +263,7 @@ class Plugin extends Container {
 	 * @return void
 	 */
 	public function loadPluginTextDomain() {
-		load_plugin_textdomain( $this->getHeader( 'text_domain' ), false, $this->basePath( ltrim( $this->getHeader( 'domain_path' ), '/' ) ) );
+		load_plugin_textdomain( $this->getHeader( 'text_domain' ), false, plugin_basename( $this->basePath( ltrim( $this->getHeader( 'domain_path' ), '/' ) ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Path to languages files in load_plugin_textdomain() function should be relative. plugin_basename() function make it relative to current plugin directory.